### PR TITLE
Termstrings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,7 +1,7 @@
 name: docs-gen
 
 on:
-  pull_request:
+  push:
     branches: [ master ]
 
 jobs:

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,11 +26,12 @@ fn main() {
     */
 
     t.write(b"Hello World");
+    
+    println!("{:?}", cmd_ts);
 
     let b1 = t.compare(cmd_ts);
     println!("{:?}", b1);
     // let b2: bool = t.compare(zsh_ts);
-    println!("{:?}", cmd_ts);
 
     // println!("{:?}", t);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::fs::File;
 
 use console_tester::buffer::TermWriter;
 */
+use std::path::Path;
 
 use console_tester::buffer::TermWriter;
 use console_tester::term::TermStrings;
@@ -15,14 +16,20 @@ use std::io::Write;
 fn main() {
     let mut t: TermWriter = TermWriter::new();
 
-    // let mut bash_ts: TermStrings = TermStrings::new(file);  // This is termcap for bash
-    // let mut zsh_ts: TermStrings = TermStrings::new(file);   // This is termcap for zsh
-    // let mut cmd_ts: TermStrings = TermStrings::new();       // This is local terminal
+    let mut cmd_ts: TermStrings = TermStrings::new_from_env();       // This is local terminal
+
+    /*
+    // Get TermStrings from terminfo database file
+    let path: Path = Path::new("./xterm");
+    let mut xterm_ts: TermStrings = TermStrings::new_from_path(path);
+    println!("{:?}", xterm_ts);
+    */
 
     t.write(b"Hello World");
 
     // let b1: bool = t.compare(bash_ts);
     // let b2: bool = t.compare(zsh_ts);
+    println!("{:?}", cmd_ts);
 
     // println!("{:?}", t);
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     #[ignore]
     fn term_struct_not_empty() {
-        let t = TermStrings::new();
+        let t = TermStrings::new_from_env();
         println!("{:?}", t.string_list);
         assert!(!t.get_term_list().is_empty());
     }
@@ -126,21 +126,21 @@ mod tests {
     #[test]
     #[ignore]
     fn check_list_for_valid_symbol() {
-        let t = TermStrings::new();
+        let t = TermStrings::new_from_env();
         assert!(t.check_valid_symbol([27, 91, 80].to_vec()));
     }
 
     #[test]
     #[ignore]
     fn check_list_for_invalid_symbol() {
-        let t = TermStrings::new();
+        let t = TermStrings::new_from_env();
         assert!(!t.check_valid_symbol([27, 27, 27].to_vec()));
     }
 
     #[test]
     #[ignore]
     fn term_strings_init_not_empty() {
-        let strings: Vec<Vec<u8>> = init();
+        let strings: Vec<Vec<u8>> = init_from_env();
         assert!(!strings.is_empty());
     }
 }

--- a/src/term.rs
+++ b/src/term.rs
@@ -5,7 +5,7 @@
 //! # Internal Example
 //! ```
 //! use console_tester::term::TermStrings;
-//! let term_strings: TermStrings = TermStrings::new();
+//! let term_strings: TermStrings = TermStrings::new_from_env();
 //! let term_list = term_strings.get_term_list();
 //! ```
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -9,10 +9,12 @@
 //! let term_list = term_strings.get_term_list();
 //! ```
 
+use std::path::{Path, PathBuf};
 use terminfo::capability;
 use terminfo::Database;
 use terminfo::names;
 
+#[derive(Debug, Clone)]
 pub struct TermStrings {
     /// Filtered list of terminal symbols
     string_list: Vec<Vec<u8>>
@@ -22,16 +24,18 @@ pub struct TermStrings {
 /// Instantiable, in order to reduce performance overhead by caching the list of strings
 /// instead of generating a new list for every check.
 /// Populates TermStrings.string_list on instantiation
-///
-/// TODO: Implement std::fmt::Debug
-/// TODO: Implement Copy trait
 impl TermStrings {
-    pub fn new() -> TermStrings {
+    pub fn new_from_env() -> TermStrings {
         TermStrings {
-            string_list: init()
+            string_list: init_from_env()
         }
     }
-
+    pub fn new_from_path(path: &Path) -> TermStrings {
+        TermStrings {
+            string_list: init_from_path(&path.to_owned())
+        }
+    }
+    
     /// Check a terminal symbol (in Vec<u8> form) against the list of valid terminal symbols
     pub fn check_valid_symbol(&self, to_compare: Vec<u8>) -> bool { self.string_list.contains(&to_compare) }
 
@@ -43,10 +47,8 @@ impl TermStrings {
 /// !Internal Function
 ///
 /// Warning, printing these symbols to the terminal may result in strange side effects
-/// TODO: change return type to Result<Vec<Vec<u8>>, Err> and match in construction.
-fn init() -> Vec<Vec<u8>> {
+fn init_from_env() -> Vec<Vec<u8>> {
 
-    // This is **BAD** you need to check for Err
     let res = Database::from_env();
 
     let info: Database;
@@ -74,6 +76,37 @@ fn init() -> Vec<Vec<u8>> {
     return strings;
 }
 
+/// Gets a Vec of u8 vectors, each containing a terminal symbol.
+/// This method takes a filepath to a terminfo file
+/// Warning, printing these symbols to the terminal may result in strange side effects
+fn init_from_path(path: &PathBuf) -> Vec<Vec<u8>> {
+
+    let res = Database::from_path(path);
+
+    let info: Database;
+
+    // File not found, or invalid terminfo file
+    if res.is_err(){
+        println!("This terminal isn't supported by the testing framework");
+        return Vec::new();
+    }
+
+    // get database object now
+    info = res.unwrap();
+
+    let mut strings = Vec::new();
+
+    for n in names::ALIASES.keys() {
+        if let Some(val) = info.raw(n) {
+            match &val {    // We're only interested in the strings, so filter those out
+                capability::Value::String(s) => strings.push(s.to_owned()),
+                capability::Value::Number(_) => (),
+                capability::Value::True => ()
+            }
+        }
+    }
+    return strings;
+}
 
 // -------------------- TESTS -----------------------
 


### PR DESCRIPTION
Implemented `Debug` and `Clone` for `TermStrings`. `Copy` is not viable because a `Vec<Vec<u8>>` is not copyable, so `Clone` was used instead.

Changed `TermStrings` constructor - now no longer has `new()`, in favor of `new_from_env()` and `new_from_path(path: &Path)`. Can now load TermStrings from a terminfo database file.